### PR TITLE
Make it work with Rails 4

### DIFF
--- a/lib/render_anywhere/rendering_controller.rb
+++ b/lib/render_anywhere/rendering_controller.rb
@@ -27,6 +27,9 @@ module RenderAnywhere
       config.javascripts_dir = Rails.root.join('public', 'javascripts')
       config.stylesheets_dir = Rails.root.join('public', 'stylesheets')
       config.assets_dir = Rails.root.join('public')
+      
+      # same asset host as the controllers
+      self.asset_host = ActionController::Base.asset_host
     end
 
     # we are not in a browser, no need for this
@@ -38,9 +41,6 @@ module RenderAnywhere
     def flash
       {}
     end
-
-    # same asset host as the controllers
-    self.asset_host = ActionController::Base.asset_host
 
     # and nil request to differentiate between live and offline
     def request


### PR DESCRIPTION
Both Rails.application.routes.url_helpers and ApplicationHelper are not available on startup when using Rails 4, leading to a crash on startup with render_anywhere. This patch avoids that by moving those calls to the initialize, where they are available. 

I have not tested this with older versions of Rails.
