### PR TITLE
don't break on cookies calls

### DIFF
--- a/lib/render_anywhere/rendering_controller.rb
+++ b/lib/render_anywhere/rendering_controller.rb
@@ -40,6 +40,11 @@ module RenderAnywhere
     # same asset host as the controllers
     self.asset_host = ActionController::Base.asset_host
 
+    # so that your cookies calls still work
+    def cookies
+      {}
+    end
+
     # and nil request to differentiate between live and offline
     def request
       nil


### PR DESCRIPTION
Without this, calling cookies in a helper or a page crashes; avoid that.
