### PR TITLE
Inherit base RenderingController from ActionController::Metal

### DIFF
--- a/lib/render_anywhere/rendering_controller.rb
+++ b/lib/render_anywhere/rendering_controller.rb
@@ -1,7 +1,7 @@
 require 'ostruct'
 
 module RenderAnywhere
-  class RenderingController < AbstractController::Base
+  class RenderingController < ActionController::Metal
     # Include all the concerns we need to make this work
     include AbstractController::Logger
     include AbstractController::Rendering


### PR DESCRIPTION
Take a look at [this](https://github.com/rails/rails/blob/master/actionpack/lib/abstract_controller/base.rb#L15) note about `AbstractController::Base`. 

And [another one](https://github.com/rails/rails/blob/master/actionpack/lib/action_controller/metal.rb#L42) about `ActionController::Metal`. 

Recently I encountered some issues with `render_anywhere` gem upgrade (from 0.0.2 version). It includes `ActionController::Caching` from version [`0.0.5`](https://github.com/airatshigapov/render_anywhere/commit/a3d4a16585b988f88418457fd4d9459a0be397dc), and `ActionController::Caching` uses `ActionController::RackDelegation` which fails at [this line](https://github.com/rails/rails/blob/master/actionpack/lib/action_controller/metal/rack_delegation.rb#L17) since `response` variable is not available if we inherit our controller from just `AbstractController::Base`

I suggest to inherit `RenderingController` from `ActionController::Metal` if possible and if it doesn't break anything (it shouldn't I guess), since it _"is the simplest possible controller"_ and it [fixes](https://github.com/rails/rails/blob/master/actionpack/lib/action_controller/metal.rb#L128) the issue with `response` variable.
