### PR TITLE
Set relative_url_root for proper assets path

### DIFF
--- a/lib/render_anywhere/rendering_controller.rb
+++ b/lib/render_anywhere/rendering_controller.rb
@@ -34,6 +34,7 @@ module RenderAnywhere
       config.stylesheets_dir = Rails.root.join('public', 'stylesheets')
       config.assets_dir = Rails.root.join('public')
       config.cache_store = ActionController::Base.cache_store
+      config.relative_url_root = ActionController::Base.relative_url_root
 
       # same asset host as the controllers
       self.asset_host = ActionController::Base.asset_host


### PR DESCRIPTION
When `RAILS_RELATIVE_URL_ROOT` is set, rendering path to assets (`javascript_include_tag`, `image_path`, `asset_path` etc...) skips this configuration.

This is the case when application is deployed to subdirectory: http://guides.rubyonrails.org/configuring.html#deploy-to-a-subdirectory-relative-url-root
